### PR TITLE
Use checkSchema to validate register body

### DIFF
--- a/src/controllers/users.controllers.ts
+++ b/src/controllers/users.controllers.ts
@@ -1,17 +1,18 @@
 import { Request, Response } from 'express'
-import User from '~/models/schemas/User.schema'
-import databaseService from '~/services/database.services'
+import usersService from '~/services/users.services'
 export const loginController = (req: Request, res: Response) => {
   res.status(200).json({ message: 'Hello World' })
 }
 
-export const registerController = (req: Request, res: Response) => {
-  // const {email, password} = req.body
-  // databaseService.users.insertOne(new User({
-  //   email,
-  //   password
-  // }))
-  return res.status(200).json({
-    message: 'Register successfully'
-  })
+export const registerController = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await usersService.register(req.body)
+    res.json({
+      message: 'Register Successfully',
+      result
+    })
+  } catch (error) {
+    console.log(error)
+    res.status(500).json({ message: 'An error occurred' })
+  }
 }

--- a/src/middlewares/users.middlewares.ts
+++ b/src/middlewares/users.middlewares.ts
@@ -1,0 +1,84 @@
+import { validate } from './../utils/validation'
+import { NextFunction, Request, Response } from 'express'
+import { checkSchema } from 'express-validator'
+
+export const loginValidator = (req: Request, res: Response, next: NextFunction) => {
+  const { email, password } = req.body
+  if (!email || !password) {
+    return res.status(400).json({
+      error: 'Missing email or password'
+    })
+  }
+  next()
+}
+
+export const registerValidator = validate(
+  checkSchema({
+    email: {
+      isEmail: true,
+      trim: true,
+      notEmpty: true
+    },
+
+    name: {
+      notEmpty: true,
+      trim: true,
+      isString: true,
+      isLength: {
+        options: {
+          min: 1,
+          max: 100
+        }
+      }
+    },
+
+    password: {
+      notEmpty: true,
+      trim: true,
+      isStrongPassword: {
+        options: {
+          minLength: 8,
+          minLowercase: 1,
+          minSymbols: 1,
+          minUppercase: 1,
+          minNumbers: 1
+        }
+      },
+      errorMessage:
+        'Password must be at least 8 characters long and contain at least 1 lowercase letter, 1 uppercase letter, 1 number, and 1 symbol'
+    },
+
+    confirm_password: {
+      notEmpty: true,
+      trim: true,
+      isStrongPassword: {
+        options: {
+          minLength: 8,
+          minLowercase: 1,
+          minSymbols: 1,
+          minUppercase: 1,
+          minNumbers: 1
+        }
+      },
+      errorMessage:
+        'Password must be at least 8 characters long and contain at least 1 lowercase letter, 1 uppercase letter, 1 number, and 1 symbol',
+      custom: {
+        options: (value, { req }) => {
+          if (value !== req.body.password) {
+            throw new Error('Password confirmation does not match password')
+          }
+          return true
+        }
+      }
+    },
+
+    date_of_birth: {
+      isISO8601: {
+        options: {
+          strict: true,
+          strictSeparator: true
+        }
+      }
+    }
+  })
+)

--- a/src/models/requests/users.requests.ts
+++ b/src/models/requests/users.requests.ts
@@ -1,0 +1,7 @@
+export interface RegisterReqBody {
+  name: string
+  email: string
+  password: string
+  confirm_password: string
+  date_of_birth: string
+}

--- a/src/routes/users.routes.ts
+++ b/src/routes/users.routes.ts
@@ -1,5 +1,16 @@
 import { Router } from 'express'
+import { registerController } from '~/controllers/users.controllers'
+import { registerValidator } from '~/middlewares/users.middlewares'
 
 const userRouter = Router()
+
+userRouter.post('/login')
+/**
+ * Description: Register a new user
+ * Path: /register
+ * method: POST
+ * Body: {name: string, email: string, password: string, confirm_password: string, date_of_birth: ISO8601}
+ */
+userRouter.post('/register', registerValidator, registerController)
 
 export default userRouter

--- a/src/services/users.services.ts
+++ b/src/services/users.services.ts
@@ -1,0 +1,21 @@
+import { ObjectId } from 'mongodb'
+import User from '~/models/schemas/User.schema'
+import databaseService from './database.services'
+import { RegisterReqBody } from '~/models/requests/users.requests'
+class UsersService {
+  async register(payload: RegisterReqBody) {
+    const user_id = new ObjectId()
+    await databaseService.users.insertOne(
+      new User({
+        ...payload,
+        _id: user_id,
+        username: `user${user_id.toString()}`,
+        date_of_birth: new Date(payload.date_of_birth),
+        password: payload.password
+      })
+    )
+  }
+}
+
+const usersService = new UsersService()
+export default usersService

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,17 @@
+import express from 'express'
+import { validationResult, ValidationChain } from 'express-validator'
+import { RunnableValidationChains } from 'express-validator/lib/middlewares/schema'
+
+// can be reused by many routes
+export const validate = (validations: RunnableValidationChains<ValidationChain>) => {
+  return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    // sequential processing, stops running validations chain if one fails.
+    await validations.run(req)
+    const errors = validationResult(req)
+    //If not error
+    if (errors.isEmpty()) {
+      return next()
+    }
+    res.status(400).json({ errors: errors.mapped() })
+  }
+}


### PR DESCRIPTION
Defines a middleware function named validate that integrates express-validator to validate incoming requests in an Express application. It processes validation rules (chains) sequentially, stops when an error occurs, and responds with a JSON error object if validation fails.

When we use this validate middleware in a route, it:

- Takes a set of validation rules (e.g., query('param').notEmpty()).
- Runs these rules against the incoming request (req).
- Checks if any validation rules failed.
- If no errors exist, it allows the request to continue by calling next().
- If errors are present, it stops further processing and responds with a 400 error and a list of validation errors.